### PR TITLE
remove deprecation warning for rails 5.1

### DIFF
--- a/lib/simple_token_authentication/sign_in_handler.rb
+++ b/lib/simple_token_authentication/sign_in_handler.rb
@@ -13,7 +13,7 @@ module SimpleTokenAuthentication
     def integrate_with_devise_trackable!(controller)
       # Sign in using token should not be tracked by Devise trackable
       # See https://github.com/plataformatec/devise/issues/953
-      controller.env["devise.skip_trackable"] = SimpleTokenAuthentication.skip_devise_trackable
+      controller.request.env["devise.skip_trackable"] = SimpleTokenAuthentication.skip_devise_trackable
     end
   end
 end

--- a/lib/simple_token_authentication/version.rb
+++ b/lib/simple_token_authentication/version.rb
@@ -1,3 +1,3 @@
 module SimpleTokenAuthentication
-  VERSION = "1.12.0"
+  VERSION = "1.12.1"
 end


### PR DESCRIPTION
DEPRECATION WARNING: env is deprecated and will be removed from Rails
5.1.

Answer from here:
http://stackoverflow.com/a/34471522/977017
